### PR TITLE
Pagination fix

### DIFF
--- a/src/plugins/pagination/get-page.js
+++ b/src/plugins/pagination/get-page.js
@@ -8,8 +8,7 @@ const getPage = (apiClient, data, direction, callback) => {
     return callback ? callback(urlError) : Promise.reject(urlError)
   }
 
-  let _paramGroups = { body: [], path: [], query: [] }
-  let requestOptions = { url,_paramGroups }
+  let requestOptions = { url }
 
   let promise = apiClient.request(requestOptions)
 

--- a/src/plugins/pagination/get-page.js
+++ b/src/plugins/pagination/get-page.js
@@ -8,7 +8,8 @@ const getPage = (apiClient, data, direction, callback) => {
     return callback ? callback(urlError) : Promise.reject(urlError)
   }
 
-  let requestOptions = { url }
+  let _paramGroups = { body: [], path: [], query: [] }
+  let requestOptions = { url,_paramGroups }
 
   let promise = apiClient.request(requestOptions)
 

--- a/src/request/request-options.js
+++ b/src/request/request-options.js
@@ -24,7 +24,7 @@ const getRequestOptions = (endpointOptions = {}) => {
     ...remainingOptions
   } = deepmerge(DEFAULT_OPTIONS, endpointOptions)
 
-  let { _paramGroups, ...params } = remainingOptions
+  let { _paramGroups = {}, ...params } = remainingOptions
 
   let paramGroups = {}
 
@@ -36,16 +36,16 @@ const getRequestOptions = (endpointOptions = {}) => {
     })
   })
 
-  url = urlTemplate.parse(url).expand(paramGroups.path)
+  url = urlTemplate.parse(url).expand(paramGroups.path || {})
   if (!/^http/.test(url)) {
     url = `${baseUrl}${url}`
   }
 
-  if (Object.keys(paramGroups.query).length) {
+  if (paramGroups.query) {
     url = addQueryParameters(url, paramGroups.query)
   }
 
-  if (Object.keys(paramGroups.body).length) {
+  if (paramGroups.body && Object.keys(paramGroups.body).length) {
     body = paramGroups.body._body || {}
 
     let bodyType = body.constructor.name


### PR DESCRIPTION
Pagination has a bug because it calls request directly, bypassing the normal attribute building:

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at getRequestOptions (/.../node_modules/bitbucket/src/request/request-options.js:34:10)
    at request (/.../node_modules/bitbucket/src/request/index.js:9:24)

when calling await bitbucket.getNextPage(response.data);

This change fixes it.