### PR TITLE
Use swagger to set accepts header

### DIFF
--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -67,9 +67,8 @@ const setConsumes = (apiObject, { consumes = [] }) => {
 }
 
 const setProduces = (apiObject, { produces = [] }) => {
-  if (!apiObject.produces) apiObject.produces = []
-  if (produces.includes('application/octet-stream')) {
-    apiObject.produces = ['application/octet-stream']
+  if (produces.length === 1) {
+    _.set(apiObject, 'headers.accept', produces[0])
   }
 }
 

--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -68,7 +68,9 @@ const setConsumes = (apiObject, { consumes = [] }) => {
 
 const setProduces = (apiObject, { produces = [] }) => {
   if (!apiObject.produces) apiObject.produces = []
-  apiObject.produces = _.uniq(apiObject.produces.concat(...produces))
+  if (produces.includes('application/octet-stream')) {
+    apiObject.produces = ['application/octet-stream']
+  }
 }
 
 const setHTTPMethod = (apiObject, method) => {

--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -66,6 +66,11 @@ const setConsumes = (apiObject, { consumes = [] }) => {
   apiObject.accepts = _.uniq(apiObject.accepts.concat(...consumes))
 }
 
+const setProduces = (apiObject, { produces = [] }) => {
+  if (!apiObject.produces) apiObject.produces = []
+  apiObject.produces = _.uniq(apiObject.produces.concat(...produces))
+}
+
 const setHTTPMethod = (apiObject, method) => {
   apiObject.method = method.toUpperCase()
 }
@@ -154,6 +159,7 @@ const updateRoutes = routesObject => {
         setParameters(routesObject[namespaceName][apiName], spec)
         if (spec[method]) {
           setConsumes(routesObject[namespaceName][apiName], spec[method])
+          setProduces(routesObject[namespaceName][apiName], spec[method])
           setParameters(routesObject[namespaceName][apiName], spec[method])
           setResponses(routesObject[namespaceName][apiName], spec[method])
         }
@@ -162,6 +168,7 @@ const updateRoutes = routesObject => {
 
         _.each(specExtras[method], (value, key) => {
           setConsumes(routesObject[namespaceName][apiName], specExtras[method])
+          setProduces(routesObject[namespaceName][apiName], specExtras[method])
           setParameters(
             routesObject[namespaceName][apiName],
             specExtras[method]

--- a/src/request/request-options.js
+++ b/src/request/request-options.js
@@ -19,6 +19,7 @@ const getRequestOptions = (endpointOptions = {}) => {
     body,
     headers,
     method,
+    produces = [],
     url,
     options: otherOptions,
     ...remainingOptions
@@ -43,6 +44,10 @@ const getRequestOptions = (endpointOptions = {}) => {
 
   if (paramGroups.query) {
     url = addQueryParameters(url, paramGroups.query)
+  }
+
+  if (produces.length > 0) {
+    headers['accept'] = produces
   }
 
   if (paramGroups.body && Object.keys(paramGroups.body).length) {

--- a/src/request/request-options.js
+++ b/src/request/request-options.js
@@ -19,7 +19,6 @@ const getRequestOptions = (endpointOptions = {}) => {
     body,
     headers,
     method,
-    produces = [],
     url,
     options: otherOptions,
     ...remainingOptions
@@ -44,10 +43,6 @@ const getRequestOptions = (endpointOptions = {}) => {
 
   if (paramGroups.query) {
     url = addQueryParameters(url, paramGroups.query)
-  }
-
-  if (produces.length === 1) {
-    headers['accept'] = produces[0]
   }
 
   if (paramGroups.body && Object.keys(paramGroups.body).length) {

--- a/src/request/request-options.js
+++ b/src/request/request-options.js
@@ -46,8 +46,8 @@ const getRequestOptions = (endpointOptions = {}) => {
     url = addQueryParameters(url, paramGroups.query)
   }
 
-  if (produces.length > 0) {
-    headers['accept'] = produces
+  if (produces.length === 1) {
+    headers['accept'] = produces[0]
   }
 
   if (paramGroups.body && Object.keys(paramGroups.body).length) {

--- a/src/routes/routes.json
+++ b/src/routes/routes.json
@@ -531,6 +531,9 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json"
+      ],
       "returns": "Repository",
       "url": "/repositories/{username}/{repo_slug}"
     },
@@ -1629,6 +1632,9 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json"
+      ],
       "returns": "Repository",
       "url": "/repositories/{username}/{repo_slug}"
     },
@@ -2325,6 +2331,9 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/octet-stream"
+      ],
       "url": "/repositories/{username}/{repo_slug}/pipelines/{pipeline_uuid}/steps/{step_uuid}/log"
     },
     "getPipelineVariable": {
@@ -3823,6 +3832,9 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json"
+      ],
       "returns": "PaginatedPullrequests",
       "url": "/repositories/{username}/{repo_slug}/commit/{commit}/pullrequests"
     },
@@ -4190,6 +4202,9 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json"
+      ],
       "returns": "Repository",
       "url": "/repositories/{username}/{repo_slug}"
     },
@@ -4749,6 +4764,11 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json",
+        "multipart/related",
+        "multipart/form-data"
+      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}"
     },
@@ -4771,6 +4791,11 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json",
+        "multipart/related",
+        "multipart/form-data"
+      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}/{node_id}"
     },
@@ -5130,6 +5155,11 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json",
+        "multipart/related",
+        "multipart/form-data"
+      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}"
     },
@@ -5157,6 +5187,11 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json",
+        "multipart/related",
+        "multipart/form-data"
+      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}/{node_id}"
     },
@@ -5700,6 +5735,9 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json"
+      ],
       "returns": "SearchResultPage",
       "url": "/teams/{username}/search/code"
     },
@@ -6199,6 +6237,9 @@
           "type": "string"
         }
       },
+      "produces": [
+        "application/json"
+      ],
       "returns": "SearchResultPage",
       "url": "/users/{username}/search/code"
     },

--- a/src/routes/routes.json
+++ b/src/routes/routes.json
@@ -531,9 +531,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json"
-      ],
       "returns": "Repository",
       "url": "/repositories/{username}/{repo_slug}"
     },
@@ -1632,9 +1629,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json"
-      ],
       "returns": "Repository",
       "url": "/repositories/{username}/{repo_slug}"
     },
@@ -3832,9 +3826,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json"
-      ],
       "returns": "PaginatedPullrequests",
       "url": "/repositories/{username}/{repo_slug}/commit/{commit}/pullrequests"
     },
@@ -4202,9 +4193,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json"
-      ],
       "returns": "Repository",
       "url": "/repositories/{username}/{repo_slug}"
     },
@@ -4764,11 +4752,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json",
-        "multipart/related",
-        "multipart/form-data"
-      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}"
     },
@@ -4791,11 +4774,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json",
-        "multipart/related",
-        "multipart/form-data"
-      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}/{node_id}"
     },
@@ -5155,11 +5133,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json",
-        "multipart/related",
-        "multipart/form-data"
-      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}"
     },
@@ -5187,11 +5160,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json",
-        "multipart/related",
-        "multipart/form-data"
-      ],
       "returns": "Snippet",
       "url": "/snippets/{username}/{encoded_id}/{node_id}"
     },
@@ -5735,9 +5703,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json"
-      ],
       "returns": "SearchResultPage",
       "url": "/teams/{username}/search/code"
     },
@@ -6237,9 +6202,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/json"
-      ],
       "returns": "SearchResultPage",
       "url": "/users/{username}/search/code"
     },

--- a/src/routes/routes.json
+++ b/src/routes/routes.json
@@ -513,6 +513,9 @@
       "url": "/repositories/{username}/{repo_slug}/default-reviewers/{target_username}"
     },
     "create": {
+      "headers": {
+        "accept": "application/json"
+      },
       "method": "POST",
       "params": {
         "_body": {
@@ -1616,6 +1619,9 @@
       "url": "/repositories/{username}/{repo_slug}/hooks/{uid}"
     },
     "get": {
+      "headers": {
+        "accept": "application/json"
+      },
       "method": "GET",
       "params": {
         "repo_slug": {
@@ -2302,6 +2308,9 @@
       "url": "/repositories/{username}/{repo_slug}/pipelines/{pipeline_uuid}/steps/{step_uuid}"
     },
     "getPipelineStepLog": {
+      "headers": {
+        "accept": "application/octet-stream"
+      },
       "method": "GET",
       "params": {
         "pipeline_uuid": {
@@ -2325,9 +2334,6 @@
           "type": "string"
         }
       },
-      "produces": [
-        "application/octet-stream"
-      ],
       "url": "/repositories/{username}/{repo_slug}/pipelines/{pipeline_uuid}/steps/{step_uuid}/log"
     },
     "getPipelineVariable": {
@@ -3792,6 +3798,9 @@
       "url": "/repositories/{username}/{repo_slug}/pullrequests"
     },
     "listPullrequestsForCommit": {
+      "headers": {
+        "accept": "application/json"
+      },
       "method": "GET",
       "params": {
         "commit": {
@@ -4175,6 +4184,9 @@
       "url": "/repositories/{username}/{repo_slug}/pipelines/{pipeline_uuid}/stopPipeline"
     },
     "update": {
+      "headers": {
+        "accept": "application/json"
+      },
       "method": "PUT",
       "params": {
         "_body": {
@@ -5682,6 +5694,9 @@
       "url": "/teams/{username}/hooks"
     },
     "searchCode": {
+      "headers": {
+        "accept": "application/json"
+      },
       "method": "GET",
       "params": {
         "page": {
@@ -6181,6 +6196,9 @@
       "url": "/users/{username}/hooks"
     },
     "searchCode": {
+      "headers": {
+        "accept": "application/json"
+      },
       "method": "GET",
       "params": {
         "page": {


### PR DESCRIPTION
Use the produces property of the swagger to determine what types should
be accepted as a response.

The [Pipelines log](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/pipelines/%7Bpipeline_uuid%7D/steps/%7Bstep_uuid%7D/log) endpoint returns `application/octet-stream` instead of `application/json`.