### PR TITLE
Remove `q:` style queries as an option for pipelines endpoints.

### DIFF
--- a/scripts/generate-routes.js
+++ b/scripts/generate-routes.js
@@ -181,15 +181,19 @@ const addFilterAndSortParams = routesObject => {
       let isPaginatedList = /^list/i.test(apiName)
       let returnsPaginated =
         apiObject.returns && /^paginated/i.test(apiObject.returns)
+      let isPipelines = /pipelines/i.test(apiObject.url)
 
       if (isPaginatedList || returnsPaginated) {
+        parameters = [
+          { in: 'query', name: 'page', require: false, type: 'string' },
+          { in: 'query', name: 'pagelen', required: false, type: 'integer' },
+          { in: 'query', name: 'sort', required: false, type: 'string' }
+        ]
+        if (!isPipelines) {
+          parameters.push({ in: 'query', name: 'q', required: false, type: 'string' })
+        }
         setParameters(apiObject, {
-          parameters: [
-            { in: 'query', name: 'page', require: false, type: 'string' },
-            { in: 'query', name: 'pagelen', required: false, type: 'integer' },
-            { in: 'query', name: 'q', required: false, type: 'string' },
-            { in: 'query', name: 'sort', required: false, type: 'string' }
-          ]
+          parameters: parameters
         })
       }
     })

--- a/src/routes/routes.json
+++ b/src/routes/routes.json
@@ -3382,10 +3382,6 @@
           "in": "query",
           "type": "integer"
         },
-        "q": {
-          "in": "query",
-          "type": "string"
-        },
         "repo_slug": {
           "in": "path",
           "required": true,
@@ -3414,10 +3410,6 @@
         "pagelen": {
           "in": "query",
           "type": "integer"
-        },
-        "q": {
-          "in": "query",
-          "type": "string"
         },
         "repo_slug": {
           "in": "path",
@@ -3448,10 +3440,6 @@
           "in": "query",
           "type": "integer"
         },
-        "q": {
-          "in": "query",
-          "type": "string"
-        },
         "repo_slug": {
           "in": "path",
           "required": true,
@@ -3480,10 +3468,6 @@
         "pagelen": {
           "in": "query",
           "type": "integer"
-        },
-        "q": {
-          "in": "query",
-          "type": "string"
         },
         "repo_slug": {
           "in": "path",
@@ -3519,10 +3503,6 @@
           "required": true,
           "type": "string"
         },
-        "q": {
-          "in": "query",
-          "type": "string"
-        },
         "repo_slug": {
           "in": "path",
           "required": true,
@@ -3551,10 +3531,6 @@
         "pagelen": {
           "in": "query",
           "type": "integer"
-        },
-        "q": {
-          "in": "query",
-          "type": "string"
         },
         "repo_slug": {
           "in": "path",
@@ -5575,10 +5551,6 @@
           "in": "query",
           "type": "integer"
         },
-        "q": {
-          "in": "query",
-          "type": "string"
-        },
         "sort": {
           "in": "query",
           "type": "string"
@@ -6073,10 +6045,6 @@
         "pagelen": {
           "in": "query",
           "type": "integer"
-        },
-        "q": {
-          "in": "query",
-          "type": "string"
         },
         "sort": {
           "in": "query",


### PR DESCRIPTION
The pipelines endpoints don't actually support this type of query.