### PR TITLE
fix: update before-after-hook to last version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -987,9 +987,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
-      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
     },
     "big.js": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "before-after-hook": "^1.1.0",
+    "before-after-hook": "^1.4.0",
     "btoa-lite": "^1.0.0",
     "debug": "^3.1.0",
     "is-plain-object": "^2.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ class Bitbucket {
   constructor(options = {}) {
     this.options = deepmerge(clientDefaults, options)
 
-    this.hook = new Hook()
+    this.hook = new Hook.Collection()
 
     this.request = this.request.bind(this)
 

--- a/src/plugins/authentication/__tests__/index.test.js
+++ b/src/plugins/authentication/__tests__/index.test.js
@@ -5,7 +5,7 @@ let apiClient
 
 beforeEach(() => {
   apiClient = {
-    hook: new Hook()
+    hook: new Hook.Collection()
   }
 })
 


### PR DESCRIPTION
We are using `node-bitbucket` in out code and we have a lot of `console.warn` messages with text `[before-after-hook]: "Hook()" repurposing warning, use "Hook.Collection()". Read more: https://git.io/upgrade-before-after-hook-to-1.4`.

It happens because you are using `^1.1.0` of `before-after-hook` which eventually resolved to `1.4.0`. They changed API a bit and added warning about it.

By this fix I'm updating `before-after-hook` to the last version.

Please see https://github.com/gr2m/before-after-hook#upgrading-to-14 for more details.