### PR TITLE
Chore/get all pullrequests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6402,10 +6402,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -6621,6 +6620,12 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,25 @@
   "name": "bitbucket",
   "version": "1.15.2",
   "description": "Bitbucket API client for Browser and Node.js",
-  "keywords": ["bitbucket", "bitbucket-api", "api-client", "api", "rest"],
+  "keywords": [
+    "bitbucket",
+    "bitbucket-api",
+    "api-client",
+    "api",
+    "rest"
+  ],
   "homepage": "https://github.com/MunifTanjim/node-bitbucket#readme",
   "bugs": "https://github.com/MunifTanjim/node-bitbucket/issues",
   "license": "MIT",
   "author": "MunifTanjim (https://muniftanjim.com)",
-  "files": ["src", "dist/*.js"],
+  "files": [
+    "src",
+    "dist/*.js"
+  ],
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "browser": {
-    "./src/utils/get-buffer-response.js":
-      "./src/utils/get-buffer-response-browser.js"
+    "./src/utils/get-buffer-response.js": "./src/utils/get-buffer-response-browser.js"
   },
   "repository": "github:MunifTanjim/node-bitbucket",
   "scripts": {
@@ -20,8 +28,7 @@
     "prebuild:browser": "mkdirp dist",
     "build:browser": "npm-run-all -p build:browser:*",
     "build:browser:development": "webpack --mode development",
-    "build:browser:production":
-      "webpack --mode production --output-filename=bitbucket.min.js",
+    "build:browser:production": "webpack --mode production --output-filename=bitbucket.min.js",
     "prebuild:docs": "mkdirp docs",
     "build:docs": "npm run generate:api-docs",
     "postbuild:docs": "apidoc -i docs -o docs",
@@ -45,6 +52,7 @@
     "debug": "^3.1.0",
     "is-plain-object": "^2.0.4",
     "node-fetch": "^2.1.2",
+    "qs": "^6.9.1",
     "url-template": "^2.0.8"
   },
   "devDependencies": {

--- a/scripts/type-defs.json
+++ b/scripts/type-defs.json
@@ -4064,13 +4064,16 @@
               "$ref": "#/definitions/PullrequestEndpoint"
             },
             "state": {
-              "enum": [
-                "MERGED",
-                "SUPERSEDED",
-                "OPEN",
-                "DECLINED"
-              ],
-              "type": "string"
+              "items": {
+                "enum": [
+                  "MERGED",
+                  "SUPERSEDED",
+                  "OPEN",
+                  "DECLINED"
+                ],
+                "type": "string"
+              },
+              "type": "array"
             },
             "summary": {
               "additionalProperties": false,

--- a/specification/definitions.json
+++ b/specification/definitions.json
@@ -4914,13 +4914,16 @@
           },
           "state": {
             "description": "The pull request's current status.",
-            "enum": [
+            "items": {
+              "enum": [
               "MERGED",
               "SUPERSEDED",
               "OPEN",
               "DECLINED"
             ],
             "type": "string"
+          },
+            "type": "array"
           },
           "summary": {
             "additionalProperties": false,

--- a/src/routes/routes.json
+++ b/src/routes/routes.json
@@ -3844,14 +3844,17 @@
           "type": "string"
         },
         "state": {
-          "enum": [
-            "MERGED",
-            "SUPERSEDED",
-            "OPEN",
-            "DECLINED"
-          ],
+          "items": {
+            "enum": [
+              "MERGED",
+              "SUPERSEDED",
+              "OPEN",
+              "DECLINED"
+            ],
+            "type": "string"
+          },
           "in": "query",
-          "type": "string"
+          "type": "array"
         },
         "username": {
           "in": "path",

--- a/src/utils/__tests__/add-query-parameters.test.js
+++ b/src/utils/__tests__/add-query-parameters.test.js
@@ -47,4 +47,11 @@ describe('utils:add-query-parameters', () => {
     })
     expect(qs).toMatchSnapshot()
   })
+
+  it('accepts array for state, so it can return all pull requests', () => {
+    let state = addQueryParameters(url, {
+      state: ['MERGED', 'OPEN']
+    })
+    expect(state).toBe('/?state=MERGED&state=OPEN')
+  })
 })

--- a/src/utils/add-query-parameters.js
+++ b/src/utils/add-query-parameters.js
@@ -4,6 +4,8 @@
  * @param {Object} params - Query Parameters
  * @returns {String} URL with added Query Parameters
  */
+const qs = require('qs')
+
 const addQueryParameters = (url, params = {}) => {
   const separator = /\?/.test(url) ? '&' : '?'
   const names = Object.keys(params)
@@ -24,6 +26,11 @@ const addQueryParameters = (url, params = {}) => {
               .join('+')
           )
           .join('+')}`
+      }
+      if (name === 'state') {
+        if (Array.isArray(params.state)) {
+          return `${qs.stringify({ state: params.state }, { arrayFormat: "repeat" })}`
+        }
       }
       return `${name}=${encodeURIComponent(params[name])}`
     })


### PR DESCRIPTION
I created this PR as I need to have a possibility to get all pull requests from Bitbucket in my open-source app (which scan your repo to recommend you the best practices to use). Here is my PR, where I have a getPullRequests() method with filtering by state. https://github.com/DXHeroes/dx-scanner/pull/164/files#diff-f600166eb00e146bad20364a8e1fa783R82

My proposal is based on Bitbucket API doc 
```By default only open pull requests are returned. This can be controlled using the state query parameter. To retrieve pull requests that are in one of multiple states, repeat the state parameter for each individual state.```

https://developer.atlassian.com/bitbucket/api/2/reference/resource/pullrequests/%7Btarget_user%7D