### PR TITLE
Updated routes for Workspaces so that create- and updateWebhook  include body

### DIFF
--- a/src/plugins/register-api-endpoints/routes.json
+++ b/src/plugins/register-api-endpoints/routes.json
@@ -5879,6 +5879,11 @@
     "updateWebhookForWorkspace": {
       "method": "PUT",
       "params": {
+        "_body": {
+          "required": true,
+          "schema": "WebhookSubscription",
+          "type": "any"
+        },
         "uid": {
           "required": true,
           "type": "string"

--- a/src/plugins/register-api-endpoints/routes.json
+++ b/src/plugins/register-api-endpoints/routes.json
@@ -5657,6 +5657,11 @@
     "createWebhookForWorkspace": {
       "method": "POST",
       "params": {
+        "_body": {
+          "required": true,
+          "schema": "WebhookSubscription",
+          "type": "any"
+        },
         "workspace": {
           "required": true,
           "type": "string"


### PR DESCRIPTION
The Schema of workspaces.createWebhookForWorkspace and workspaces.updateWebhookForWorkspaces was missing a body to actually provide the webhook details. This is a required 'field' for the Bitbucket API