### PR TITLE
Fix Cannot read property 'headers' of undefined

### DIFF
--- a/src/endpoint/merge.ts
+++ b/src/endpoint/merge.ts
@@ -17,7 +17,7 @@ export function merge(
       endpointOptions
     )
   } else {
-    endpointOptions = endpointRoute
+    endpointOptions = endpointRoute || {}
   }
 
   endpointOptions.headers = lowerCaseHeaderFields(endpointOptions.headers)


### PR DESCRIPTION
This fixes errors the "Cannot read property 'headers' of undefined" error when trying to use the user.get() (and possibly other) functions.