### PR TITLE
[fix] Remove auth header from the error

### DIFF
--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -3,6 +3,20 @@ type RequestOptions = import('./types').RequestOptions
 
 type AbstractHTTPError = import('./types').HTTPError
 
+function sanitizeRequest(request: RequestOptions | undefined): RequestOptions | undefined {
+  if (!request) return request
+
+  const sanitizedHeaders = { ...request.headers }
+  if (sanitizedHeaders.authorization) {
+    sanitizedHeaders.authorization = '[REDACTED]'
+  }
+  
+  return {
+    ...request,
+    headers: sanitizedHeaders
+  }
+}
+
 export class HTTPError extends Error implements AbstractHTTPError {
   public error: any | undefined
   public headers: Headers | undefined
@@ -26,7 +40,7 @@ export class HTTPError extends Error implements AbstractHTTPError {
     this.name = 'HTTPError'
     this.error = options.error
     this.headers = options.headers
-    this.request = options.request
+    this.request = sanitizeRequest(options.request)
     this.status = statusCode
   }
 }


### PR DESCRIPTION
The error has the full request information (including the authorization in the header), this PR redacts the auth from the header.

Addresses this Issue: https://github.com/MunifTanjim/node-bitbucket/issues/142  